### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/PagedList.Tests/PagedList.Tests.csproj
+++ b/PagedList.Tests/PagedList.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/PagedList.Tests/PagedListNavigationTests.cs
+++ b/PagedList.Tests/PagedListNavigationTests.cs
@@ -1,0 +1,54 @@
+namespace PagedList.Tests;
+
+public class PagedListNavigationTests
+{
+    private static PagedList<int> Build(int pageNumber, int pageSize, int total)
+    {
+        return new PagedList<int>(new List<int>(), pageNumber, pageSize, total);
+    }
+
+    [Fact]
+    public void Constructor_SetsAllProperties()
+    {
+        var items = new List<int> { 1, 2, 3 };
+        var list = new PagedList<int>(items, 2, 10, 25);
+
+        Assert.Same(items, list.Items);
+        Assert.Equal(2, list.PageNumber);
+        Assert.Equal(10, list.PageSize);
+        Assert.Equal(25, list.Total);
+    }
+
+    [Theory]
+    [InlineData(1, 10, 25, true)]
+    [InlineData(3, 10, 25, false)]
+    [InlineData(2, 10, 25, true)]
+    public void HasNextPage_ReturnsExpected(int pageNumber, int pageSize, int total, bool expected)
+    {
+        Assert.Equal(expected, Build(pageNumber, pageSize, total).HasNextPage());
+    }
+
+    [Theory]
+    [InlineData(1, 10, 25, 2)]
+    [InlineData(3, 10, 25, 1)]
+    public void NextPage_ReturnsExpected(int pageNumber, int pageSize, int total, int expected)
+    {
+        Assert.Equal(expected, Build(pageNumber, pageSize, total).NextPage());
+    }
+
+    [Theory]
+    [InlineData(1, 10, 25, false)]
+    [InlineData(2, 10, 25, true)]
+    public void HasPreviousPage_ReturnsExpected(int pageNumber, int pageSize, int total, bool expected)
+    {
+        Assert.Equal(expected, Build(pageNumber, pageSize, total).HasPreviousPage());
+    }
+
+    [Theory]
+    [InlineData(2, 10, 25, 1)]
+    [InlineData(1, 10, 25, 3)]
+    public void PreviousPage_ReturnsExpected(int pageNumber, int pageSize, int total, int expected)
+    {
+        Assert.Equal(expected, Build(pageNumber, pageSize, total).PreviousPage());
+    }
+}

--- a/PagedList.csproj
+++ b/PagedList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PagedList/PagedList.csproj
+++ b/PagedList/PagedList.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.301",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Summary
Surgical upgrade of the PagedList library from .NET 9 to .NET 10. No source code logic changed.

Version references bumped:
- All three `.csproj` files: `<TargetFramework>net9.0</TargetFramework>` → `net10.0`
- `global.json`: SDK `9.0.100` → `10.0.301`
- `.github/workflows/dotnet.yml`: `dotnet-version: 9.0.x` → `10.0.x`

No Microsoft.* framework-tied packages needed bumping (test-only deps unchanged). Build succeeds with 0 warnings/errors and all tests pass under net10.0.

## Test coverage
The `PagedList` library (domain/core layer) was at 53% line coverage — only `LastPage()` was exercised. Added `PagedListNavigationTests.cs` covering the previously-untested members (`HasNextPage`, `NextPage`, `HasPreviousPage`, `PreviousPage`, and the constructor/properties), bringing line coverage to 100% (16 tests, all passing). No existing tests were modified.


Link to Devin session: https://app.devin.ai/sessions/3600ff94ba8b49f88f56a52ea7379e2b
Requested by: @grimley517
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/grimley517/pagedlist/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->